### PR TITLE
Convert intrinsics abstraction functions that require constants to macros.

### DIFF
--- a/common/simd/v128_intrinsics_arm.h
+++ b/common/simd/v128_intrinsics_arm.h
@@ -493,118 +493,27 @@ SIMD_INLINE v128 v128_shr_s32(v128 a, unsigned int c) {
   return (c > 31) ? v128_ones() : vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(a), vdupq_n_s32(-c)));
 }
 
-#if __OPTIMIZE__
-
-SIMD_INLINE v128 v128_shl_n_byte(v128 a, const unsigned int n) {
-  return n < 8 ?
-    v128_from_64(vorr_u64(vshl_n_u64(vreinterpret_u64_s64(vget_high_s64(a)), n*8),
-                          vshr_n_u64(vreinterpret_u64_s64(vget_low_s64(a)), (8-n)*8)),
-                 vshl_n_u64(vreinterpret_u64_s64(vget_low_s64(a)), n*8)) :
-    (n == 8 ? v128_from_64(vreinterpret_u64_s64(vget_low_s64(a)), 0) :
-     v128_from_64(vshl_n_u64(vreinterpret_u64_s64(vget_low_s64(a)), (n-8)*8), 0));
-}
-
-SIMD_INLINE v128 v128_shr_n_byte(v128 a, const unsigned int n) {
-  return n < 8 ?
-    v128_from_64(vshr_n_u64(vreinterpret_u64_s64(vget_high_s64(a)), n*8),
-                 vorr_u64(vshr_n_u64(vreinterpret_u64_s64(vget_low_s64(a)), n*8),
-                          vshl_n_u64(vreinterpret_u64_s64(vget_high_s64(a)), (8-n)*8))) :
-    (n == 8 ? v128_from_64(0, vreinterpret_u64_s64(vget_high_s64(a))) :
-     v128_from_64(0, vshr_n_u64(vreinterpret_u64_s64(vget_high_s64(a)), (n-8)*8)));
-}
-
-SIMD_INLINE v128 v128_shl_n_8(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u8(vshlq_n_u8(vreinterpretq_u8_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_u8(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u8(vshrq_n_u8(vreinterpretq_u8_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_s8(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_s8(vshrq_n_s8(vreinterpretq_s8_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shl_n_16(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u16(vshlq_n_u16(vreinterpretq_u16_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_u16(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u16(vshrq_n_u16(vreinterpretq_u16_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_s16(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_s16(vshrq_n_s16(vreinterpretq_s16_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shl_n_32(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u32(vshlq_n_u32(vreinterpretq_u32_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_u32(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_u32(vshrq_n_u32(vreinterpretq_u32_s64(a), c));
-}
-
-SIMD_INLINE v128 v128_shr_n_s32(v128 a, const unsigned int c) {
-  return vreinterpretq_s64_s32(vshrq_n_s32(vreinterpretq_s32_s64(a), c));
-}
-
-#else
-
-SIMD_INLINE v128 v128_shl_n_byte(v128 a, const unsigned int n) {
-  if (n < 8)
-    return v128_from_v64(v64_or(v64_shl_n_byte(v128_high_v64(a), n),
-                                v64_shr_n_byte(v128_low_v64(a), 8 - n)),
-                         v64_shl_n_byte(v128_low_v64(a), n));
-  else
-    return v128_from_v64(v64_shl_n_byte(v128_low_v64(a), n - 8), v64_zero());
-}
-
-SIMD_INLINE v128 v128_shr_n_byte(v128 a, const unsigned int n) {
-  if (n < 8)
-    return v128_from_v64(v64_shr_n_byte(v128_high_v64(a), n),
-                         v64_or(v64_shr_n_byte(v128_low_v64(a), n),
-                                v64_shl_n_byte(v128_high_v64(a), 8 - n)));
-  else
-    return v128_from_v64(v64_zero(), v64_shr_n_byte(v128_high_v64(a), n - 8));
-}
-
-SIMD_INLINE v128 v128_shl_n_8(v128 a, const unsigned int c) {
-  return v128_shl_8(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_u8(v128 a, const unsigned int c) {
-  return v128_shr_u8(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_s8(v128 a, const unsigned int c) {
-  return v128_shr_s8(a, c);
-}
-
-SIMD_INLINE v128 v128_shl_n_16(v128 a, const unsigned int c) {
-  return v128_shl_16(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_u16(v128 a, const unsigned int c) {
-  return v128_shr_u16(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_s16(v128 a, const unsigned int c) {
-  return v128_shr_s16(a, c);
-}
-
-SIMD_INLINE v128 v128_shl_n_32(v128 a, const unsigned int c) {
-  return v128_shl_32(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_u32(v128 a, const unsigned int c) {
-  return v128_shr_u32(a, c);
-}
-
-SIMD_INLINE v128 v128_shr_n_s32(v128 a, const unsigned int c) {
-  return v128_shr_s32(a, c);
-}
-
-#endif
+/* These intrinsics require immediate values on some architectures,
+   so we must use #defines to enforce that. */
+/* Not really an issue for arm, but lets replicate any side effects
+   on these architectures */
+#define v128_shl_n_u8(a, c) vreinterpretq_s64_u8(vshlq_n_u8( \
+ vreinterpretq_u8_s64(a), c))
+#define v128_shr_n_u8(a, c) vreinterpretq_s64_u8(vshrq_n_u8( \
+ vreinterpretq_u8_s64(a), c))
+#define v128_shr_n_s8(a, c) vreinterpretq_s64_s8(vshrq_n_s8( \
+ vreinterpretq_s8_s64(a), c))
+#define v128_shl_n_u16(a, c) vreinterpretq_s64_u16(vshlq_n_u16( \
+ vreinterpretq_u16_s64(a), c))
+#define v128_shr_n_u16(a, c) vreinterpretq_s64_u16(vshrq_n_u16( \
+ vreinterpretq_u16_s64(a), c))
+#define v128_shr_n_s16(a, c) vreinterpretq_s64_s16(vshrq_n_s16( \
+ vreinterpretq_s16_s64(a), c))
+#define v128_shl_n_u32(a, c) vreinterpretq_s64_u32(vshlq_n_u32( \
+ vreinterpretq_u32_s64(a), c))
+#define v128_shr_n_u32(a, c) vreinterpretq_s64_u32(vshrq_n_u32( \
+ vreinterpretq_u32_s64(a), c))
+#define v128_shr_n_s32(a, c) vreinterpretq_s64_s32(vshrq_n_s32( \
+ vreinterpretq_s32_s64(a), c))
 
 #endif /* _V128_INTRINSICS_H */

--- a/common/simd/v64_intrinsics_arm.h
+++ b/common/simd/v64_intrinsics_arm.h
@@ -464,98 +464,30 @@ SIMD_INLINE v64 v64_shr_s32(v64 a, unsigned int c) {
   return vreinterpret_s64_s32(vshl_s32(vreinterpret_s32_s64(a), vdup_n_s32(-(int)c)));
 }
 
-#if __OPTIMIZE__
-
-SIMD_INLINE v64 v64_shl_n_byte(v64 a, const unsigned int c) {
-  return vshl_n_s64(a, c * 8);
-}
-
-SIMD_INLINE v64 v64_shr_n_byte(v64 a, const unsigned int c) {
-  return c ? vshr_n_u64(vreinterpret_u64_s64(a), c * 8) : a;
-}
-
-SIMD_INLINE v64 v64_shl_n_8(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u8(vshl_n_u8(vreinterpret_u8_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_u8(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u8(vshr_n_u8(vreinterpret_u8_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_s8(v64 a, const unsigned int c) {
-  return vreinterpret_s64_s8(vshr_n_s8(vreinterpret_s8_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shl_n_16(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u16(vshl_n_u16(vreinterpret_u16_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_u16(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u16(vshr_n_u16(vreinterpret_u16_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_s16(v64 a, const unsigned int c) {
-  return vreinterpret_s64_s16(vshr_n_s16(vreinterpret_s16_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shl_n_32(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u32(vshl_n_u32(vreinterpret_u32_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_u32(v64 a, const unsigned int c) {
-  return vreinterpret_s64_u32(vshr_n_u32(vreinterpret_u32_s64(a), c));
-}
-
-SIMD_INLINE v64 v64_shr_n_s32(v64 a, const unsigned int c) {
-  return vreinterpret_s64_s32(vshr_n_s32(vreinterpret_s32_s64(a), c));
-}
-
-#else
-
-SIMD_INLINE v64 v64_shl_n_byte(v64 a, const unsigned int c) {
-  return v64_from_64(v64_u64(a) << c*8);
-}
-
-SIMD_INLINE v64 v64_shr_n_byte(v64 a, const unsigned int c) {
-  return v64_from_64(v64_u64(a) >> c*8);
-}
-
-SIMD_INLINE v64 v64_shl_n_8(v64 a, const unsigned int c) {
-  return v64_shl_8(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_u8(v64 a, const unsigned int  c) {
-  return v64_shr_u8(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_s8(v64 a, const unsigned int c) {
-  return v64_shr_s8(a, c);
-}
-
-SIMD_INLINE v64 v64_shl_n_16(v64 a, const unsigned int c) {
-  return v64_shl_16(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_u16(v64 a, const unsigned int c) {
-  return v64_shr_u16(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_s16(v64 a, const unsigned int c) {
-  return v64_shr_s16(a, c);
-}
-
-SIMD_INLINE v64 v64_shl_n_32(v64 a, const unsigned int c) {
-  return v64_shl_32(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_u32(v64 a, const unsigned int c) {
-  return v64_shr_u32(a, c);
-}
-
-SIMD_INLINE v64 v64_shr_n_s32(v64 a, const unsigned int c) {
-  return v64_shr_s32(a, c);
-}
-
-#endif
+/* These intrinsics require immediate values on some architectures,
+   so we must use #defines to enforce that. */
+/* Not really an issue for arm, but lets replicate any side effects
+   on these architectures */
+#define v64_shl_n_byte(a, c) vshl_n_s64(a, c * 8)
+#define v64_shr_n_byte(a, c) (c ? vshr_n_u64(vreinterpret_u64_s64(a) \
+ , c * 8) : a)
+#define v64_shl_n_8(a, c) vreinterpret_s64_u8(vshl_n_u8( \
+ vreinterpret_u8_s64(a), c))
+#define v64_shr_n_u8(a, c) vreinterpret_s64_u8(vshr_n_u8( \
+ vreinterpret_u8_s64(a), c))
+#define v64_shr_n_s8(a, c) vreinterpret_s64_s8(vshr_n_s8( \
+ vreinterpret_s8_s64(a), c))
+#define v64_shl_n_16(a, c) vreinterpret_s64_u16(vshl_n_u16( \
+ vreinterpret_u16_s64(a), c))
+#define v64_shr_n_u16(a, c) vreinterpret_s64_u16(vshr_n_u16( \
+ vreinterpret_u16_s64(a), c))
+#define v64_shr_n_s16(a, c) vreinterpret_s64_s16(vshr_n_s16( \
+ vreinterpret_s16_s64(a), c))
+#define v64_shl_n_32(a, c) vreinterpret_s64_u32(vshl_n_u32( \
+ vreinterpret_u32_s64(a), c))
+#define v64_shr_n_u32(a, c) vreinterpret_s64_u32(vshr_n_u32( \
+ vreinterpret_u32_s64(a), c))
+#define v64_shr_n_s32(a, c) vreinterpret_s64_s32(vshr_n_s32( \
+ vreinterpret_s32_s64(a), c))
 
 #endif /* _V64_INTRINSICS_H */


### PR DESCRIPTION
Some intrinsics functions include parameters that are encoded into the
instruction and therefore must be constant. GCC can figure this out when
inlining, however Clang cannot. This is solved by converting these functions
into macros.