### PR TITLE
fix build on MAC

### DIFF
--- a/enc/strings.c
+++ b/enc/strings.c
@@ -29,6 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string.h>
 #include "global.h"
 #include "strings.h"
+#include "mainenc.h"
 
 #define MAX_PARAMS 200
 


### PR DESCRIPTION
the master code can't be build,  include  mainenc.h is missing.    this patch intend to fix the build issue. 
