### PR TITLE
Fix delta_qp

### DIFF
--- a/dec/decode_block.c
+++ b/dec/decode_block.c
@@ -635,7 +635,7 @@ void process_block_dec(decoder_info_t *decoder_info,int size,int yposY,int xposY
 #endif
   
   /* Read delta_qp and set block-level qp */
-  if (size==MAX_BLOCK_SIZE && mode != MODE_SKIP && decoder_info->max_delta_qp > 0){
+  if (size==MAX_BLOCK_SIZE && (split_flag || mode != MODE_SKIP) && decoder_info->max_delta_qp > 0){
     /* Read delta_qp */
     int delta_qp = read_delta_qp(stream);
     decoder_info->frame_info.qpb = decoder_info->frame_info.qp + delta_qp;


### PR DESCRIPTION
Decoder fails to read delta_qp in P-frame super blocks when split_flag=1
(mode is initialized to MODE_SKIP by default).